### PR TITLE
Fix cfg syntax error

### DIFF
--- a/GameData/PatchManager/Lang/NotValidated/fr-fr.cfg
+++ b/GameData/PatchManager/Lang/NotValidated/fr-fr.cfg
@@ -13,7 +13,7 @@
 			pm_overrideinfo = Cela remplace la fonction du bouton caché s'il n'y a pas de correctifs en raison de dépendances
 			pm_doesNot = Ceci ne permet pas de désactiver / activer le mod, que vous pouvez faire dans les paramètres standard:
 			pm_alwaysShow = Toujours afficher le bouton de la barre d'outils
-			pm_disable this is = Désactiver ceci pour stocker les correctifs actifs dans le dossier parent parent du patch
+			pm_disablethis = Désactiver ceci pour stocker les correctifs actifs dans le dossier parent parent du patch
 			pm_storeactive = Enregistrer les correctifs actifs dans le dossier PatchManager
 			pm_ok = D'accord
 			pm_changesmade1 = Les modifications que vous venez de faire en installant / désinstaller un ou


### PR DESCRIPTION
Hi @linuxgurugamer,

I've been working on some cfg parser code for KSP-CKAN/CKAN#3525, and I tested it on this mod and found a minor syntax error in the French translation: extra spaces and letters for the `pm_disablethis` key. Here's what it looks like for the other languages:

https://github.com/linuxgurugamer/PatchManager/blob/ced23517b3108d1c1cdaa3fe506ffde8f7bc6489/GameData/PatchManager/Lang/de-de.cfg#L16
https://github.com/linuxgurugamer/PatchManager/blob/ced23517b3108d1c1cdaa3fe506ffde8f7bc6489/GameData/PatchManager/Lang/en-us.cfg#L16
https://github.com/linuxgurugamer/PatchManager/blob/ced23517b3108d1c1cdaa3fe506ffde8f7bc6489/GameData/PatchManager/Lang/es-es.cfg#L26
https://github.com/linuxgurugamer/PatchManager/blob/ced23517b3108d1c1cdaa3fe506ffde8f7bc6489/GameData/PatchManager/Lang/pt-br.cfg#L15
https://github.com/linuxgurugamer/PatchManager/blob/ced23517b3108d1c1cdaa3fe506ffde8f7bc6489/GameData/PatchManager/Lang/ru.cfg#L16
https://github.com/linuxgurugamer/PatchManager/blob/ced23517b3108d1c1cdaa3fe506ffde8f7bc6489/GameData/PatchManager/Lang/NotValidated/ja.cfg#L16

This pull request fixes that.

Cheers!