### PR TITLE
Don't save settings outside game folder

### DIFF
--- a/PatchManager/PatchInfo.cs
+++ b/PatchManager/PatchInfo.cs
@@ -147,10 +147,10 @@ namespace PatchManager
             }
 
             fname = srcPath.Substring(srcPath.LastIndexOf('/') + 1);
-            bool bd = Directory.Exists(destPath) || File.Exists(destPath);
+            bool bd = Directory.Exists(KSPUtil.ApplicationRootPath + destPath) || File.Exists(KSPUtil.ApplicationRootPath + destPath);
             if (installedWithMod)
             {
-                enabled = File.Exists(destPath + "/" + fname);
+                enabled = File.Exists(KSPUtil.ApplicationRootPath + destPath + "/" + fname);
             }
             else
             {
@@ -162,7 +162,7 @@ namespace PatchManager
                 else
                 {
                     enabled = false;
-                    DirectoryInfo di = Directory.CreateDirectory(destPath);
+                    DirectoryInfo di = Directory.CreateDirectory(KSPUtil.ApplicationRootPath + destPath);
                     // Shouldn't ever happen, but if it does, create the directory
                 }
             }

--- a/PatchManager/PatchManager.cs
+++ b/PatchManager/PatchManager.cs
@@ -62,7 +62,7 @@ namespace PatchManager
             DEFAULT_PATCH_DIRECTORY = "GameData/PatchManager/ActiveMMPatches";
             CFG_DIR = "GameData/PatchManager/PluginData";
             LoadAllPatches();
-            settings.LoadSettings(CFG_DIR);
+            settings.LoadSettings(KSPUtil.ApplicationRootPath + CFG_DIR);
 
             windowPosition = new Rect((Screen.width - WIDTH) / 2, (Screen.height - HEIGHT) / 2, WIDTH, HEIGHT);
 
@@ -113,7 +113,7 @@ namespace PatchManager
             toolbarControl.AddToAllToolbars(onTrue, onFalse,
                 ApplicationLauncher.AppScenes.SPACECENTER,
                 MODID,
-                "patchManagerButton﻿",
+                "patchManagerButton",
                 "PatchManager/Resources/PatchManager-38",
                 "PatchManager/Resources/PatchManager-24",
                 MODNAME
@@ -213,7 +213,7 @@ namespace PatchManager
             if (GUILayout.Button(Localizer.Format("pm_ok"), GUILayout.Width(60)))
             {
                 showSettings = false;
-                settings.SaveSettings(CFG_DIR);
+                settings.SaveSettings(KSPUtil.ApplicationRootPath + CFG_DIR);
                 CheckPatchLocations();
             }
             GUILayout.FlexibleSpace();


### PR DESCRIPTION
Hi @linuxgurugamer,

A user spotted an "orphaned GameData" folder containing some of this mod's settings after running the game:

- https://forum.kerbalspaceprogram.com/index.php?/topic/209890-rp-1-on-linux-mint-21-cant-enter-space-centre-buildings-so-i-cant-start-a-game-solved/&do=findComment&comment=4179073

![image](https://user-images.githubusercontent.com/1559108/192300316-94314162-1604-4ac7-8675-e192d9e44a85.png)

This happens because `PatchInfo.destPath` and `PatchManager.CFG_DIR` are relative paths, and a few of the places that use them do not prepend the game path (though some other spots do).

![reproduced](https://i.imgur.com/8JSWSBq.png)

Now all places that use these variables prepend the game path, so these files and folders should save to the right folder.
